### PR TITLE
Fixed example config and a small error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /static/bower_components
 /node_modules
 /.idea
+/.DS_Store
 # Created by .ignore support plugin (hsz.mobi)

--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,8 @@
 {
     "username": "admin",
     "password": "admin",
-    "port": 8080,
+    "trackerPort": 8844,
+    "httpPort": 8080,
     "databasePath": "database",
-    "googleMapsAPIKey": "YOURAPIKEY"
+    "googleMapsAPIKey": "APIKEY"
 }

--- a/server.js
+++ b/server.js
@@ -119,7 +119,7 @@ router.get('/trackerlist', auth, function(req, res) {
             res.send(500, err.message);
         else
             if (docs) {
-                var list = [ docs[0].trackerId ];
+                var list = [];
                 for (var i=0; i<docs.length; i++) {
                     if (list.indexOf(docs[i].trackerId)==-1)
                         list.push(docs[i].trackerId);
@@ -139,5 +139,5 @@ app.get("/", auth, function(req, res) {
 
 app.listen(config.httpPort, function () {
     console.log('GeoServer frontend listening on port ' + config.httpPort);
-    console.log('Tracking listening on port ' + config.trackingPort);
+    console.log('Tracking listening on port ' + config.trackerPort);
 });


### PR DESCRIPTION
Fixed the example config (httpPort and trackerPort), fixed the use of trackingPort and trackerPort and fixed a crash when the list of trackers is empty.
